### PR TITLE
updated portal jar versions to 2.0.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,13 +253,13 @@
 			<dependency>
 				<groupId>com.liferay.portal</groupId>
 				<artifactId>com.liferay.portal.kernel</artifactId>
-				<version>1.0.4-SNAPSHOT</version>
+				<version>2.0.1-SNAPSHOT</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>com.liferay.portal</groupId>
 				<artifactId>com.liferay.util.taglib</artifactId>
-				<version>1.0.1-SNAPSHOT</version>
+				<version>2.0.1-SNAPSHOT</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
This should be backported to 4.x also.
