### PR TITLE
FACES-3173 - Exclude **/internal/** packages from javadoc generation

### DIFF
--- a/bridge-atmosphere/pom.xml
+++ b/bridge-atmosphere/pom.xml
@@ -128,10 +128,13 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<!-- MJAVADOC-275: Need version 2.8 or higher for release:prepare to generate JavaDoc -->
-					<version>2.10.3</version>
+					<version>2.10.4</version>
 					<configuration>
 						<additionalparam>-Xdoclint:all -Xdoclint:-missing</additionalparam>
+						<sourceFileExcludes>
+							<exclude>**/internal/*.java</exclude>
+						</sourceFileExcludes>
+						<excludePackageNames>*.internal.*</excludePackageNames>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/bridge-ext/pom.xml
+++ b/bridge-ext/pom.xml
@@ -131,10 +131,13 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<!-- MJAVADOC-275: Need version 2.8 or higher for release:prepare to generate JavaDoc -->
-					<version>2.10.3</version>
+					<version>2.10.4</version>
 					<configuration>
 						<additionalparam>-Xdoclint:all -Xdoclint:-missing</additionalparam>
+						<sourceFileExcludes>
+							<exclude>**/internal/*.java</exclude>
+						</sourceFileExcludes>
+						<excludePackageNames>*.internal.*</excludePackageNames>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/bridge-ext/src/main/java/com/liferay/faces/bridge/ext/context/internal/HeadResponseWriterLiferayImpl.java
+++ b/bridge-ext/src/main/java/com/liferay/faces/bridge/ext/context/internal/HeadResponseWriterLiferayImpl.java
@@ -40,7 +40,7 @@ import com.liferay.taglib.util.HtmlTopTag;
 
 
 /**
- * Custom {@link ResponseWriter} that has the ability to write to the <head>...</head> section of the portal page via
+ * Custom {@link ResponseWriter} that has the ability to write to the 'head' section of the portal page via
  * the Liferay vendor-specific mechanism.
  *
  * @author  Neil Griffin

--- a/bridge-ext/src/main/java/com/liferay/faces/bridge/ext/event/internal/LiferaySharedPageTop.java
+++ b/bridge-ext/src/main/java/com/liferay/faces/bridge/ext/event/internal/LiferaySharedPageTop.java
@@ -33,7 +33,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 
 /**
  * This class provides the ability to parse the {@link StringBundler} value of the LIFERAY_SHARED_PAGE_TOP request
- * attribute and remove duplicate CSS and/or JavaScript resources that are meant to be rendered in the <head>...</head>
+ * attribute and remove duplicate CSS and/or JavaScript resources that are meant to be rendered in the 'head'
  * section of the Liferay Portal page.
  *
  * @author  Neil Griffin

--- a/bridge-ext/src/main/java/com/liferay/faces/bridge/ext/filter/internal/LiferayURLGenerator.java
+++ b/bridge-ext/src/main/java/com/liferay/faces/bridge/ext/filter/internal/LiferayURLGenerator.java
@@ -53,7 +53,7 @@ public interface LiferayURLGenerator {
 	 * @param   portletMode             The portlet mode.
 	 * @param   windowState             The window state.
 	 *
-	 * @return
+	 * @return  The Liferay-compatible URL.
 	 */
 	public String generateURL(Map<String, String[]> additionalParameterMap, PortletMode portletMode,
 		WindowState windowState);


### PR DESCRIPTION
This should be forward ported unless it breaks the build because of FACES-3192