### PR TITLE
FACES-2958 bridge creates invalid URLs when view params contain spaces in liferay (fix forward-port compile errors)

### DIFF
--- a/bridge-ext/src/main/java/com/liferay/faces/bridge/ext/filter/internal/HeaderResponseBridgeLiferayImpl.java
+++ b/bridge-ext/src/main/java/com/liferay/faces/bridge/ext/filter/internal/HeaderResponseBridgeLiferayImpl.java
@@ -47,20 +47,17 @@ public class HeaderResponseBridgeLiferayImpl extends HeaderResponseWrapper {
 
 	@Override
 	public PortletURL createActionURL() throws IllegalStateException {
-		return liferayURLFactory.getLiferayActionURL(portletContext, headerRequest, getResponse(),
-				isFriendlyURLMapperEnabled());
+		return liferayURLFactory.getLiferayActionURL(headerRequest, getResponse(), isFriendlyURLMapperEnabled());
 	}
 
 	@Override
 	public PortletURL createRenderURL() throws IllegalStateException {
-		return liferayURLFactory.getLiferayRenderURL(portletContext, headerRequest, getResponse(),
-				isFriendlyURLMapperEnabled());
+		return liferayURLFactory.getLiferayRenderURL(headerRequest, getResponse(), isFriendlyURLMapperEnabled());
 	}
 
 	@Override
 	public ResourceURL createResourceURL() throws IllegalStateException {
-		return liferayURLFactory.getLiferayResourceURL(portletContext, headerRequest, getResponse(),
-				isFriendlyURLMapperEnabled());
+		return liferayURLFactory.getLiferayResourceURL(headerRequest, getResponse(), isFriendlyURLMapperEnabled());
 	}
 
 	@Override

--- a/bridge-ext/src/main/java/com/liferay/faces/bridge/ext/filter/internal/LiferayURLGeneratorBaseImpl.java
+++ b/bridge-ext/src/main/java/com/liferay/faces/bridge/ext/filter/internal/LiferayURLGeneratorBaseImpl.java
@@ -156,7 +156,8 @@ public abstract class LiferayURLGeneratorBaseImpl implements LiferayURLGenerator
 		parse();
 	}
 
-	public static String encodeParameterNameOrValue(String nameOrValue, String encoding) throws UnsupportedEncodingException {
+	public static String encodeParameterNameOrValue(String nameOrValue, String encoding)
+		throws UnsupportedEncodingException {
 
 		String encodedNameOrValue = nameOrValue;
 


### PR DESCRIPTION
@ngriffin7a, please merge this to `master` and backport to `6.x` **only**.